### PR TITLE
Added undefined check for session.passport

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function cleanupPassportSession(req, res, next) {
 		}
 		ended = true;
 
-		if (req.session && Object.keys(req.session.passport).length === 0) {
+		if (req.session && req.session.passport && Object.keys(req.session.passport).length === 0) {
 			delete req.session.passport;
 		}
 		_end.call(res, chunk, encoding);


### PR DESCRIPTION
I've been seeing:

TypeError: Object.keys called on non-object
25-Aug-2015 09:21:05        at Function.keys (native)
25-Aug-2015 09:21:05        at ServerResponse.end (/home/bamboo/bamboo-agent-home/xml-data/build-dir/SEIT-AIT-JOB1/tmp/overlay-management-system/node_modules/express-session-passport-cleanup/index.js:10:29)

errors on our build server and this patch should fix this.

Thanks for the project by the way.
